### PR TITLE
feat: Add standalone ChatGPT conversation scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python virtual environment
+venv/
+__pycache__/
+
+# Session and data files
+session.json
+data/
+*.jsonl
+
+# IDE and OS files
+.vscode/
+.idea/
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# NotumV1
+# Notum - Collecteur de Données ChatGPT
+
+Ce projet contient un outil pour télécharger une copie de toutes vos conversations depuis votre compte ChatGPT.
+
+## Comment l'utiliser
+
+L'utilisation est conçue pour être aussi simple que possible.
+
+### Prérequis
+
+- Vous devez être sur un système d'exploitation Linux (comme Ubuntu).
+- Vous devez avoir `git` et `python3` installés.
+
+### Instructions
+
+1.  **Clonez le projet (si ce n'est pas déjà fait)**
+    Ouvrez un terminal et clonez ce projet sur votre ordinateur.
+    ```bash
+    git clone <URL_DU_PROJET>
+    cd <NOM_DU_DOSSIER_DU_PROJET>
+    ```
+
+2.  **Exécutez le lanceur**
+    Dans le terminal, à l'intérieur du dossier du projet, lancez la commande suivante :
+    ```bash
+    ./lancer_le_scraper.sh
+    ```
+    Vous pouvez aussi souvent double-cliquer sur le fichier `lancer_le_scraper.sh` depuis votre explorateur de fichiers.
+
+### Première utilisation
+
+- La première fois que vous lancez le script, il installera tout ce qui est nécessaire (cela peut prendre quelques minutes).
+- Une fenêtre de navigateur s'ouvrira. Vous devrez vous y connecter à votre compte ChatGPT.
+- Une fois connecté, revenez au terminal et appuyez sur la touche `Entrée`.
+- La session de connexion sera sauvegardée dans un fichier `session.json`.
+
+### Utilisations suivantes
+
+- Lancez simplement `./lancer_le_scraper.sh` à nouveau.
+- Le script utilisera la session sauvegardée pour se connecter automatiquement et commencera à télécharger vos conversations.
+
+## Où sont sauvegardées les données ?
+
+Les conversations seront sauvegardées dans un dossier `data/` qui sera créé automatiquement. Le fichier s'appellera `chatgpt_conversations.jsonl`.

--- a/lancer_le_scraper.sh
+++ b/lancer_le_scraper.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# This script automates the setup and execution of the ChatGPT scraper.
+# It ensures a virtual environment is used and all dependencies are installed.
+
+# --- Configuration ---
+VENV_DIR="venv"
+REQUIREMENTS_FILE="requirements.txt"
+SCRIPT_FILE="scraper.py"
+
+# --- Functions ---
+function print_info {
+    echo "--- $1 ---"
+}
+
+function print_error {
+    echo "ERREUR: $1" >&2
+    exit 1
+}
+
+# --- Main Execution ---
+
+# 1. Check if Python3 is available
+if ! command -v python3 &> /dev/null; then
+    print_error "Python 3 n'est pas installé. Veuillez l'installer pour continuer."
+fi
+
+# 2. Set up Virtual Environment
+if [ ! -d "$VENV_DIR" ]; then
+    print_info "Création de l'environnement virtuel dans le dossier '$VENV_DIR'..."
+    python3 -m venv "$VENV_DIR"
+    if [ $? -ne 0 ]; then
+        print_error "Échec de la création de l'environnement virtuel."
+    fi
+fi
+
+# 3. Activate Virtual Environment
+print_info "Activation de l'environnement virtuel..."
+source "$VENV_DIR/bin/activate"
+if [ $? -ne 0 ]; then
+    print_error "Échec de l'activation de l'environnement virtuel."
+fi
+
+# 4. Install/Update Dependencies
+print_info "Installation des dépendances depuis '$REQUIREMENTS_FILE'..."
+pip install -r "$REQUIREMENTS_FILE"
+if [ $? -ne 0 ]; then
+    print_error "Échec de l'installation des dépendances."
+fi
+
+# 5. Install Playwright browsers
+print_info "Installation des navigateurs pour Playwright (cela peut prendre un moment)..."
+playwright install --with-deps
+if [ $? -ne 0 ]; then
+    print_error "Échec de l'installation des navigateurs Playwright."
+fi
+
+# 6. Run the Scraper
+print_info "Lancement du script de scraping..."
+python3 "$SCRIPT_FILE"
+if [ $? -ne 0 ]; then
+    print_error "Le script de scraping s'est terminé avec une erreur."
+fi
+
+print_info "Le script a terminé son exécution."
+
+# Deactivate the virtual environment upon completion
+deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+playwright
+playwright-stealth

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,133 @@
+import asyncio
+import os
+import json
+from playwright.async_api import async_playwright
+from playwright_stealth.stealth import stealth
+
+SESSION_FILE = "session.json"
+DATA_DIR = "data"
+OUTPUT_FILE = os.path.join(DATA_DIR, "chatgpt_conversations.jsonl")
+
+async def authenticate_and_save_session():
+    """
+    Launches a browser for the user to log in manually.
+    Saves the session state (cookies, etc.) to a file for future use.
+    """
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        context = await browser.new_context()
+        page = await context.new_page()
+
+        # Apply stealth measures to avoid detection
+        await stealth(page)
+
+        print("="*80)
+        print("Une fenêtre de navigateur va s'ouvrir. Veuillez vous connecter à votre compte ChatGPT.")
+        print("Une fois connecté, revenez à ce terminal et appuyez sur Entrée.")
+        print("="*80)
+
+        await page.goto("https://chat.openai.com/")
+
+        try:
+            input("Appuyez sur Entrée ici après vous être connecté dans le navigateur...")
+
+            print("\nConnexion confirmée. Sauvegarde de la session...")
+
+            storage_state = await context.storage_state()
+            with open(SESSION_FILE, 'w') as f:
+                json.dump(storage_state, f, indent=4)
+
+            print(f"Session sauvegardée dans '{SESSION_FILE}'. Le navigateur va se fermer.")
+
+        except Exception as e:
+            print(f"\nUne erreur est survenue : {e}")
+        finally:
+            await browser.close()
+
+async def scrape_conversations():
+    """
+    Uses a saved session to log in headlessly and scrape all conversations.
+    """
+    if not os.path.exists(SESSION_FILE):
+        print(f"Fichier de session '{SESSION_FILE}' non trouvé. Veuillez d'abord vous authentifier.")
+        return
+
+    print("Démarrage du scraping en utilisant la session sauvegardée...")
+    all_conversations = []
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        try:
+            context = await browser.new_context(storage_state=SESSION_FILE)
+            page = await context.new_page()
+            await stealth(page)
+
+            print("Connexion en cours...")
+            await page.goto("https://chat.openai.com/")
+
+            # Wait for the main page to load by checking for the prompt textarea
+            await page.wait_for_selector("#prompt-textarea", timeout=60000)
+            print("Connexion réussie.")
+
+            print("Recherche des liens de conversation...")
+            conv_link_selector = "a[href*='/c/']"
+            await page.wait_for_selector(conv_link_selector, timeout=60000)
+
+            conv_elements = await page.query_selector_all(conv_link_selector)
+            urls = sorted(list(set([await link.get_attribute("href") for link in conv_elements])))
+            print(f"Trouvé {len(urls)} liens de conversation uniques.")
+
+            for i, url_path in enumerate(urls):
+                full_url = f"https://chat.openai.com{url_path}"
+                print(f"Scraping de la conversation {i+1}/{len(urls)}: {url_path}")
+                await page.goto(full_url)
+                await page.wait_for_selector("div[data-message-author-role]", timeout=60000)
+
+                # Extract title and messages
+                title = await page.title()
+                messages = []
+                message_containers = await page.query_selector_all("div[data-message-author-role]")
+                for container in message_containers:
+                    role = await container.get_attribute("data-message-author-role")
+                    # The actual message content is inside a div that is a sibling of the author icon
+                    content_div = await container.query_selector("div.prose")
+                    content = await content_div.inner_text() if content_div else ""
+                    messages.append({"role": role, "content": content.strip()})
+
+                all_conversations.append({
+                    "url": full_url,
+                    "title": title,
+                    "messages": messages
+                })
+                await asyncio.sleep(1) # Be respectful to the server
+
+        except Exception as e:
+            print(f"Une erreur est survenue pendant le scraping : {e}")
+            print("Cela peut être dû à un changement dans l'interface de ChatGPT ou à une session expirée.")
+            print("Essayez de supprimer le fichier 'session.json' et de vous ré-authentifier.")
+        finally:
+            await browser.close()
+            print("Scraping terminé.")
+
+    if all_conversations:
+        # Ensure data directory exists
+        os.makedirs(DATA_DIR, exist_ok=True)
+        print(f"Sauvegarde de {len(all_conversations)} conversations dans {OUTPUT_FILE}...")
+        with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+            for conversation in all_conversations:
+                f.write(json.dumps(conversation, ensure_ascii=False) + '\n')
+        print("Sauvegarde terminée.")
+
+async def main():
+    """
+    Main function to orchestrate the authentication or scraping process.
+    """
+    if not os.path.exists(SESSION_FILE):
+        await authenticate_and_save_session()
+        if os.path.exists(SESSION_FILE):
+            print("\nAuthentification réussie. Lancez à nouveau le script pour commencer le scraping.")
+    else:
+        await scrape_conversations()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This commit introduces a robust and user-friendly tool to scrape conversations from a user's ChatGPT account.

This solution was built from a clean slate to resolve previous issues and focuses on simplicity and automation.

The main components are:
- `scraper.py`: A Python script that handles the core logic of authentication and scraping using Playwright and playwright-stealth.
- `lancer_le_scraper.sh`: A shell script that fully automates the setup and execution, including creating a virtual environment and installing all dependencies.
- `README.md`: Provides clear and simple instructions for the end-user.
- `requirements.txt` and `.gitignore`: Standard project setup files.